### PR TITLE
chore: usar arquivo .env com as variaveis obrigatorias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# INFOS SONAR
+SONAR_SERVER=http://<sonar-host-server>:<port>
+SONAR_PROJECT_KEY=<project-key>
+SONAR_TOKEN=<token>
+
+# AUTORIZAR DEPLOY PRODUCAO
+ALLOW_PRD_DEPLOYMENT=<boolean>
+
+# NOME DA IMAGEM SEM TAG
+IMAGE_NAME=<image-name>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Arquivo de variaveis de ambiente
+.env
+
 # Eclipse
 .project
 .classpath

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,36 @@
-# Variaveis
-ALLOW_PRD_DEPLOYMENT := true
+# =========== VARIAVEIS DE AMBIENTE ==============
+
+# Importa variaveis presentes no arquivo
+include .env
+
+# Torna as variaveis disponiveis no Makefile e shell scripts chamados
+export $(shell sed 's/=.*//' .env)
+
+# Caso a variavel nao esteja definida, use false e exporta para comandos shell
+ALLOW_PRD_DEPLOYMENT ?= false
+export ALLOW_PRD_DEPLOYMENT
+
 VERSION ?= $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout 2>/dev/null || 0.0.0-SNAPSHOT)
 COMMIT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "beta")
-IMAGE_NAME := quarkus-app
-IMAGE_NAME_WITH_TAG := $(IMAGE_NAME):$(VERSION)-$(COMMIT_SHA)
+DATE_WITH_SEC := $(shell date +%Y%m%d%H%M%S)
+IMAGE_NAME ?= quarkus-app
+IMAGE_NAME_WITH_TAG := $(IMAGE_NAME):$(VERSION)-$(COMMIT_SHA)-$(DATE_WITH_SEC)
 IMAGE_NAME_WITH_LATEST_TAG := $(IMAGE_NAME):latest
+
+
+# ======= ORDEM DE EXECUÇÃO DA PIPELINE ==========
 
 .PHONY: pipeline build sonar minikube-check minikube-load \
 		deploy-des verify-app-availability-des check-prd-permission deploy-prd verify-app-availability-prd clean
 
-# Pipeline completa
 pipeline: build sonar minikube-check minikube-load \
 		  deploy-des verify-app-availability-des check-prd-permission deploy-prd verify-app-availability-prd
+	@echo "======================================================================================================="
+	@echo "FIM DA PIPELINE"
+	@echo "======================================================================================================="
 
-# ========== ETAPAS DO PIPELINE ==================
+
+# ========== ETAPAS Da PIPELINE ==================
 
 # ETAPA 01: Faz o build da imagem docker com tags SemVer e latest
 build:
@@ -21,7 +38,7 @@ build:
 
 # ETAPA 01.5: Faz analise estatica com sonar e envia relatorio para o sonar server
 sonar:
-	@./ci-scripts/sonar.sh
+	@./ci-scripts/sonar.sh $(SONAR_SERVER) $(SONAR_PROJECT_KEY) $(SONAR_TOKEN)
 
 # ETAPA 02: Verifica se minikube está ativo
 minikube-check:

--- a/ci-scripts/check_prd_perm.sh
+++ b/ci-scripts/check_prd_perm.sh
@@ -11,6 +11,10 @@ if [[ "$ALLOW_PRD_DEPLOYMENT" == "true" ]]; then
   echo "✅ Permissão concedida para deploy em PRD.✅";
   exit 0;
 else
-  echo "❌🔒 Deploy em PRD bloqueado por configuracao. ❌ Encerrando com codigo ";
+  echo "❌🔒 Deploy em PRD bloqueado por configuracao. 🔒❌"
+  echo "======================================================================================================="
+	echo "FIM DA PIPELINE"
+	echo "======================================================================================================="
+  echo "Encerrando com codigo:"
   exit 78;
 fi

--- a/ci-scripts/sonar.sh
+++ b/ci-scripts/sonar.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker build -t java-sonar-pipeline -f infra/sonar-scanner/Dockerfile .
+echo "======================================================================================================="
+echo "[PERMISSION] 🕵️‍♂️ Analise Sonarqube..."
+echo "-------------------------------------------------------------------------------------------------------"
 
-docker run --rm --network host java-sonar-pipeline bash -c "
+SONAR_SERVER="${1:-}";  SONAR_PROJECT_KEY="${2:-}" SONAR_TOKEN="${3:-}" 
+
+[ -z "$SONAR_SERVER" -o -z "$SONAR_PROJECT_KEY" -o -z "$SONAR_TOKEN" ] && \
+    { echo "uso: $0 <http://sonar-host:port> <project-key> <token_sonar>"; exit 1; }
+
+docker build -t sonar-scanner-quarkus -f infra/sonar-scanner/Dockerfile .
+
+docker run --rm --network host sonar-scanner-quarkus bash -c "
     mvn clean verify sonar:sonar \
-      -Dsonar.projectKey=meu-projeto-java \
-      -Dsonar.host.url=http://localhost:9000 \
-      -Dsonar.login=sqp_30ed57d7d605b1942d8e3bf61b16d273f8ca6eb1 \
+      -Dsonar.host.url=${SONAR_SERVER} \
+      -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
+      -Dsonar.login=${SONAR_TOKEN} \
       -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 "

--- a/docs/03-pipeline.md
+++ b/docs/03-pipeline.md
@@ -6,7 +6,8 @@ A automação foi implementada usando **Makefile** e **scripts bash** (presentes
 
 ## 3.1. Executar a Pipeline
 
-Antes de executar a Pipeline Local, certifique-se de que o ambiente esteja preparado. Se necessário, reveja o item: [2. Instalação e Setup do Ambiente](./02-instalacao-setup-ambiente.md).
+Antes de executar a Pipeline Local, **certifique-se de que o ambiente esteja preparado**. Por exemplo, criar um arquivo `.env` a partir do `.env.example` na raiz do projeto informando as variáveis obrigatórias e seus respectivos valores
+Se necessário, reveja o item: [2. Instalação e Setup do Ambiente](./02-instalacao-setup-ambiente.md), que contém todas as configurações necessárias para que o ambiente fique para execução.
 
 Para disparar a Pipeline local, utiliza-se o [GNU Make](https://www.gnu.org/software/make/#download). No arquivo `./Makefile` existe um target agregador (ou meta-target) chamado **pipeline**, cujo único propósito é chamar outros targets numa sequência definida (a sequência de tasks que compõe a pipeline).
 


### PR DESCRIPTION
Este PR:
- adiciona `.env` no `.gitignore`.
- elimina variáveis hardcoded no código;
- cria arquivo `.env.example` contendo as variáveis que precisam ser definidas para o correto funcionamento do código;
- modifica os scripts de Pipeline para utilizar os valores presentes no arquivo .env (o qual deve ser criado localmente);
- adciona na documentação informações relevantes de como configurar o arquivo `.env`.
 Closes #9 