### PR TITLE
docs: explica a estrategia de versionamento (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A aplicação escolhida foi baseada no projeto [quarkus-getting-started](https:/
 
 ## Documentos Importantes
 
-> Os Links abaixo levam para documentos presentes no diretório **`docs/`**. Visite-os para entender os requisitos, como preparar o ambiente, como executar a pipeline localmente e como validar a aplicação.
+> Os Links abaixo levam para documentos presentes no diretório **`docs/`**. Visite-os para entender os requisitos, como preparar o ambiente, como é o versionamento, como executar a pipeline localmente e como validar a aplicação.
 >
 > - [1. Requisitos](./docs/01-requisitos.md)
 > - [2. Instalação e Setup do Ambiente](./docs/02-instalacao-setup-ambiente.md)

--- a/docs/02-instalacao-setup-ambiente.md
+++ b/docs/02-instalacao-setup-ambiente.md
@@ -105,17 +105,23 @@ Para subir SonarQube localmente, é possível aplicar esse comando:
 docker run -d --name sonarserver -p 9000:9000 sonarqube:9.9.8-community
 ```
 
-Alternativamente, você pode usar o docker-compose.yaml disponível em **`./infra/sonar-server/docker-compose.yaml`**. Basta abrir o terminal, acessar o diretório (`cd infra/sonar-server`) e aplicar o comando a seguir:
+Alternativamente, você pode usar o docker-compose.yaml disponível em **`./infra/sonar-server/docker-compose.yaml`**. Basta abrir o terminal na raiz do projeto e aplicar o comando a seguir:
 
 ```bash
-docker compose -p sonarserver up -d
-
+# supondo terminal na raiz do projeto
 docker compose \
   -f infra/sonar-server/docker-compose.yaml \
   -p sonarserver up -d
 ```
 
-A principal vantagem de usar o arquivo docker-compose.yaml disponível é que ele cria volumes para a persistência dos dados das análises.
+Obs.: Caso o terminal esteja posicionado no diretório **infra/sonar-server** (`cd infra/sonar-server`), é suficiente rodar:
+
+```bash
+# supondo terminal posicionado em infra/sonar-server
+docker compose -p sonarserver up -d
+```
+
+A principal vantagem de usar o arquivo docker-compose.yaml é que ele cria volumes para a persistência dos dados das análises.
 Lembre-se de verificar se o container está ativo:
 
 ```bash
@@ -130,7 +136,7 @@ docker compose -p sonarserver down
 
 ### 2.4.2. Configurar usuário e obter token
 
-Com o servidor do sonarqube disponível, acesse [http://localhost:9000](http://localhost:9000).
+Com o servidor do Sonarqube disponível, acesse [http://localhost:9000](http://localhost:9000).
 As credenciais são
 
 ```
@@ -180,7 +186,8 @@ Substitua o valores entre `< >` pelo real valor da variável. Por exemplo, no it
 - **`IMAGE_NAME` -** Nome da imagem, desconsiderando a tag (caso não esteja definida, a pipeline usa `quarkus-app`)
 
 > **Atenção, insira as informações SEM aspas!**
-> Para ilustrar um exemplo de `.env` devidamente preenchido, observe a seguir:
+
+Para ilustrar um exemplo de `.env` devidamente preenchido, observe a seguir:
 
 ```bash
 SONAR_SERVER=http://localhost:9000

--- a/docs/03-pipeline.md
+++ b/docs/03-pipeline.md
@@ -4,14 +4,35 @@
 
 A automação foi implementada usando **Makefile** e **scripts bash** (presentes no diretório **`ci-scripts/`**), simulando o comportamento de uma pipeline CI/CD.
 
-## 3.1. Executar a Pipeline
+# 3.1. Estratégia de Versionamento
 
-Antes de executar a Pipeline Local, **certifique-se de que o ambiente esteja preparado**. Por exemplo, criar um arquivo `.env` a partir do `.env.example` na raiz do projeto informando as variáveis obrigatórias e seus respectivos valores
+A pipeline gera automaticamente duas tags para cada build de imagem Docker:
+
+- `latest`
+- `<versão-do-pom>-<hash-curto-do-commit>-<yyyymmddHHMMSS>`
+
+Utiliza-se a segunda para deploy no cluster Minikube, garantindo unicidade na combinação **imagem:tag**. Sobre os elementos que compõe a segunda tag:
+
+- `<versão-do-pom>` vem direto do elemento `<version>` do `pom.xml`, seguindo o [versionamento semântico](https://semver.org/). Por exemplo, `1.1.0-SNAPSHOT`, `1.2.0`.
+- `<hash-curto-do-commit>` são os primeiros sete caracteres do SHA do commit atual, permitindo rastrear exatamente qual revisão gerou a build (ex.: `4eaf90c`).
+- `<yyyymmddHHMMSS>` é um carimbo de data/hora até segundos (ex.: `20250824012931`), garantindo unicidade a cada execução e fazendo com que o Minikube/Kubernetes detecte sempre uma nova imagem e acione o redeploy automaticamente.
+
+Logo, para o repositorio de container `quarkus-app`, alguns exemplos de tags válidas são apresentados abaixo:
+
+- **nome completo da imagem:** `quarkus-app:1.1.0-SNAPSHOT-4eaf90c-20250824012931`
+  tag: `1.1.0-SNAPSHOT-4eaf90c-20250824012931`
+- **nome completo da imagem:** `quarkus-app:1.2.0-45d0459-20250822104259`
+  tag: `1.2.0-45d0459-20250822104259`
+
+## 3.2. Executar a Pipeline
+
+Antes de executar a Pipeline Local, **certifique-se de que o ambiente esteja preparado**. Por exemplo, criar um arquivo `.env` a partir do `.env.example` na raiz do projeto, informando as variáveis obrigatórias e seus respectivos valores.
+
 Se necessário, reveja o item: [2. Instalação e Setup do Ambiente](./02-instalacao-setup-ambiente.md), que contém todas as configurações necessárias para que o ambiente fique para execução.
 
 Para disparar a Pipeline local, utiliza-se o [GNU Make](https://www.gnu.org/software/make/#download). No arquivo `./Makefile` existe um target agregador (ou meta-target) chamado **pipeline**, cujo único propósito é chamar outros targets numa sequência definida (a sequência de tasks que compõe a pipeline).
 
-> Importante: lembre-se de dá permissão de execução para os scripts shell da pasta ci-scripts/
+> **IMPORTANTE**: Lembre-se de dá permissão de execução para os scripts shell da pasta ci-scripts/
 >
 > ```bash
 > sudo chmod -R +x ci-scripts/
@@ -25,7 +46,7 @@ make pipeline
 
 No terminal, é possível observar a sequência de etapas sendo aplicadas.
 
-## 3.2. Etapas da Pipeline
+## 3.3. Etapas da Pipeline
 
 A pipeline executa a seguinte sequência de etapas:
 
@@ -36,7 +57,7 @@ A pipeline executa a seguinte sequência de etapas:
    - Para a imagem final, usa `eclipse-temurin:17-jr`, apropriada para ambiente de execução
    - Cria imagens de container com as tags:
      - `latest`
-     - `<versão-do-pom>-<hash-curto-do-commit-atual>` (ex.: `1.1.0-SNAPSHOT-4eaf90c`)
+     - `<versão-do-pom>-<hash-curto-do-commit-atual>-<yyyymmddHHMMSS>` (ex.: `1.1.0-SNAPSHOT-4eaf90c-20250824012931`)
 
 1. **Análise Estática**
 


### PR DESCRIPTION
Este PR:
- adiciona uma seção de estratégia de versionamento, explicando como foi definida a tag das imagens utilizadas no deploy da aplicação;
- Utiliza-se:
  - `latest` e
  - `<versão-do-pom>-<hash-curto-do-commit>-<yyyymmddHHMMSS>`


Solves #11 